### PR TITLE
Create Inheritable Logger Class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .env
-*log*
+*log.*
 
 # Testing and Coverage
 __pycache__/

--- a/src/InternetStatusReporter.py
+++ b/src/InternetStatusReporter.py
@@ -1,13 +1,15 @@
 import asyncio
 from os import getenv
+from src.MailLogger import MailLogger
 
-class InternetStatusReporter:
+class InternetStatusReporter(MailLogger):
   def __init__(self):
+    super().__init__()
+
     from dotenv import load_dotenv, find_dotenv
     from src.utils import get_addresses
 
     load_dotenv(find_dotenv())
-    self.__setup_logger()
 
     self.NETWORK_STATUS = {
       'NORMAL': 0,
@@ -41,32 +43,6 @@ class InternetStatusReporter:
 
   def __is_down(self):
     return self.current_status != self.NETWORK_STATUS['NORMAL']
-
-  def __setup_logger(self):
-    from logging import ERROR, INFO, basicConfig, getLogger, Formatter
-    from src.MailHandler import MailHandler
-
-    logFormat = '%(asctime)s - %(levelname)s: %(message)s'
-    basicConfig(
-      filename=getenv('LOG_FILE'),
-      filemode='a',
-      format=logFormat,
-      level=INFO
-    )
-
-    mailHandler = MailHandler(
-      (getenv('SMTP_SERVER'), getenv('SMTP_PORT')),
-      getenv('PI_EMAIL'),
-      getenv('MAILTO').split(','),
-      'Internet Status Reporter: ERROR!',
-      (getenv('PI_EMAIL'), getenv('PI_EMAIL_PASSWORD'))
-    )
-    mailHandler.setLevel(ERROR)
-    mailHandler.setFormatter(Formatter(logFormat))
-
-    self.logger = getLogger('ISR_Logger')
-    self.logger.addHandler(mailHandler)
-    self.logger.info('InternetStatusReporter is starting up')
 
   async def run(self):
     loss = self.check_status()

--- a/src/MailLogger.py
+++ b/src/MailLogger.py
@@ -1,0 +1,30 @@
+class MailLogger:
+  def __init__(self):
+    from dotenv import load_dotenv, find_dotenv
+    from logging import ERROR, INFO, basicConfig, getLogger, Formatter
+    from src.MailHandler import MailHandler
+    from os import getenv
+
+    load_dotenv(find_dotenv())
+
+    logFormat = '%(asctime)s - %(levelname)s: %(message)s'
+    basicConfig(
+      filename=getenv('LOG_FILE'),
+      filemode='a',
+      format=logFormat,
+      level=INFO
+    )
+
+    mailHandler = MailHandler(
+      (getenv('SMTP_SERVER'), getenv('SMTP_PORT')),
+      getenv('PI_EMAIL'),
+      getenv('MAILTO').split(','),
+      'Internet Status Reporter: ERROR!',
+      (getenv('PI_EMAIL'), getenv('PI_EMAIL_PASSWORD'))
+    )
+    mailHandler.setLevel(ERROR)
+    mailHandler.setFormatter(Formatter(logFormat))
+
+    self.logger = getLogger('%s_Logger' % self.__class__.__name__)
+    self.logger.addHandler(mailHandler)
+    self.logger.info('%s is starting up' % self.__class__.__name__)

--- a/src/tests/InternetStatusReporter_test.py
+++ b/src/tests/InternetStatusReporter_test.py
@@ -1,6 +1,6 @@
 import unittest
 from freezegun import freeze_time
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 from src.InternetStatusReporter import InternetStatusReporter
 
 class TestInternetStatusReporter(unittest.TestCase):

--- a/src/tests/MailLogger_test.py
+++ b/src/tests/MailLogger_test.py
@@ -3,19 +3,21 @@ from unittest.mock import MagicMock, patch
 from src.MailLogger import MailLogger
 
 class TestMailLogger(unittest.TestCase):
+  @classmethod
+  def setUpClass(self):
+    self.logger = MagicMock()
+    self.mail_handler = MagicMock()
+
   @patch('logging.getLogger')
   @patch('src.MailHandler.MailHandler')
   def test_mail_logger_initializes_correctly(self, mail_handler_mock, get_logger_mock):
-    mail_handler_instance_mock = MagicMock()
-    mail_handler_mock.return_value = mail_handler_instance_mock
-
-    logger_mock = MagicMock()
-    get_logger_mock.return_value = logger_mock
+    mail_handler_mock.return_value = self.mail_handler
+    get_logger_mock.return_value = self.logger
 
     MailLogger()
 
-    mail_handler_instance_mock.setLevel.assert_called_once()
-    mail_handler_instance_mock.setFormatter.assert_called_once()
+    self.mail_handler.setLevel.assert_called_once()
+    self.mail_handler.setFormatter.assert_called_once()
     get_logger_mock.assert_called_once_with('MailLogger_Logger')
-    logger_mock.addHandler.assert_called_once_with(mail_handler_instance_mock)
-    logger_mock.info.assert_called_once_with('MailLogger is starting up')
+    self.logger.addHandler.assert_called_once_with(self.mail_handler)
+    self.logger.info.assert_called_once_with('MailLogger is starting up')

--- a/src/tests/MailLogger_test.py
+++ b/src/tests/MailLogger_test.py
@@ -1,0 +1,21 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from src.MailLogger import MailLogger
+
+class TestMailLogger(unittest.TestCase):
+  @patch('logging.getLogger')
+  @patch('src.MailHandler.MailHandler')
+  def test_mail_logger_initializes_correctly(self, mail_handler_mock, get_logger_mock):
+    mail_handler_instance_mock = MagicMock()
+    mail_handler_mock.return_value = mail_handler_instance_mock
+
+    logger_mock = MagicMock()
+    get_logger_mock.return_value = logger_mock
+
+    MailLogger()
+
+    mail_handler_instance_mock.setLevel.assert_called_once()
+    mail_handler_instance_mock.setFormatter.assert_called_once()
+    get_logger_mock.assert_called_once_with('MailLogger_Logger')
+    logger_mock.addHandler.assert_called_once_with(mail_handler_instance_mock)
+    logger_mock.info.assert_called_once_with('MailLogger is starting up')


### PR DESCRIPTION
### What 
As we're developing new features and log points, it became quickly apparent that the `MailLogger` was needed to provide an easy logging setup to other classes.

### Changes
- Created
  - a `MailLogger` class which has all the setup work involved for creating a logger that will send emails
  - a test file for the `MailLogger`
- Updated
  - the `InternetStatusReporter` to inherit the `MailLogger` class, and removed the old setup for the logger
  - the test file for the `InternetStatusReporter` to remove a useless import
  - the `.gitignore`
