### PR TITLE
Attempt #3 to fix the Coverage Workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,6 +19,7 @@ jobs:
         run: |
           python3 -m pip install -r requirements.txt
           python3 -m pip install -r requirements-dev.txt
+          cp .env.sample .env
           
       - name: Generate coverage
         run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # internet-status-reporter
 
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/db9ca02c405e41b0be621f3c68643e14)](https://app.codacy.com/manual/erunks/internet-status-reporter?utm_source=github.com&utm_medium=referral&utm_content=erunks/internet-status-reporter&utm_campaign=Badge_Grade_Dashboard) [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/b7c7e48d9e4a494b9e0873486a0799e6)](https://www.codacy.com/manual/erunks/internet-status-reporter?utm_source=github.com&utm_medium=referral&utm_content=erunks/internet-status-reporter&utm_campaign=Badge_Coverage)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/db9ca02c405e41b0be621f3c68643e14)](https://app.codacy.com/manual/erunks/internet-status-reporter?utm_source=github.com&utm_medium=referral&utm_content=erunks/internet-status-reporter&utm_campaign=Badge_Grade_Dashboard) [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/b7c7e48d9e4a494b9e0873486a0799e6)](https://www.codacy.com/manual/erunks/internet-status-reporter?utm_source=github.com&utm_medium=referral&utm_content=erunks/internet-status-reporter&utm_campaign=Badge_Coverage) ![Build](https://github.com/erunks/internet-status-reporter/workflows/CI/badge.svg?branch=master&event=push)
 
 Since it seems inevitable that an ISP will suck at giving a reliable connection, I've decided to build this app to report all the internet outtages that occur.
 


### PR DESCRIPTION
## What
The coverage workflow is still broken. This is yet another attempt to fix it. Since there is no great way to test these workflows beforehand, it's a little tough to make sure they'll work in production.

## Changes
- Updated
  - `README.md` to include the build status badge
  - `coverage` workflow to copy over the `.env.sample` to create a `.env` for the tests