### PR TITLE
Drop `lxml` as a parser

### DIFF
--- a/src/ModemReporter.py
+++ b/src/ModemReporter.py
@@ -21,7 +21,7 @@ class ModemReporter(DatabaseInteractor):
   def __setup_browser(self):
     from mechanicalsoup import StatefulBrowser
 
-    self.browser = StatefulBrowser()
+    self.browser = StatefulBrowser(soup_config={'features': 'html.parser'})
     self.browser.set_verbose(2)
 
   def run(self):

--- a/src/tests/ModemReporter_test.py
+++ b/src/tests/ModemReporter_test.py
@@ -246,7 +246,7 @@ class TestModemReporter(unittest.TestCase):
 
     page_mock = MagicMock()
     self.modemReporter.browser.get_current_page.return_value = page_mock
-    page_mock.find.return_value = BeautifulSoup(TABLE_ROWS_SOUP, 'lxml')
+    page_mock.find.return_value = BeautifulSoup(TABLE_ROWS_SOUP, 'html.parser')
 
     self.assertEqual(
       self.modemReporter.scrape_events(),


### PR DESCRIPTION
## What
`Lxml` was causing issues with the `ModemReporter`, as it couldn't be found on the Pi. Because of this, information wasn't able to be parsed, and thus we were losing the modem logs. Instead, we're switching to the standard `html.parser`, which is supposed to be a standard integration in Python 3.

## Changes
- Added
  -  `soup_config`s to add the `html.parser` feature to the `StatefulBrowser` in our `ModemReporter`
- Updated
  - the test for the `scrape_events` method in the `ModemReporter` class, to reflect the parser change
