### PR TITLE
Add more robust logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pip
 MechanicalSoup
 mysql.connector
 pingparsing

--- a/src/DatabaseInteractor.py
+++ b/src/DatabaseInteractor.py
@@ -57,6 +57,8 @@ class DatabaseInteractor(MailLogger):
 
     except:
       self.logger.exception(f'Unexpected error: {exc_info()[0]}')
+      self.logger.info(f'SQL to execute: {sql}')
+      self.logger.indo(f'Values: {values}')
 
   def execute_sql_with_commit(self, sql, values = None):
     try:
@@ -70,3 +72,5 @@ class DatabaseInteractor(MailLogger):
 
     except:
       self.logger.exception(f'Unexpected error: {exc_info()[0]}')
+      self.logger.info(f'SQL to execute: {sql}')
+      self.logger.indo(f'Values: {values}')


### PR DESCRIPTION
## What
After updating the parser from `lxml` to `html.parser`, we began running into some SQL syntax errors, which are hard to solve without knowing what the SQL trying to be executed was. This PR adds some extra logging in places where we can gain that insight. 

## Changes
- Added
  - extra info logs for when errors happen here in the future, involving SQL execution
- Updated
  - the `requirements` file to make sure the version of `pip` is up to date
