### PR TITLE
[BUG FIX]: Update ModemReporter

### DIFF
--- a/src/ModemReporter.py
+++ b/src/ModemReporter.py
@@ -80,7 +80,7 @@ class ModemReporter(DatabaseInteractor):
     try:
       self.connect_database()
       sql = "INSERT INTO `modem_events` (`description`, `priority`, `created_at`, `maintenance`) VALUES "
-      value_string = '(%s, %s, %s, %s)'
+      value_string = '("%s", %s, "%s", %s)'
 
       event_datetime = None
       value_list = []

--- a/src/tests/ModemReporter_test.py
+++ b/src/tests/ModemReporter_test.py
@@ -139,7 +139,7 @@ class TestModemReporter(unittest.TestCase):
       ['Wed Sep 09 11:00:00 2020', 'Error (4)', 'The description'],
       ['Thu Sep 10 09:00:00 2020', 'Error (4)', 'The description']
     ]
-    SQL_QUERY = "INSERT INTO `modem_events` (`description`, `priority`, `created_at`, `maintenance`) VALUES (The description, 4, 2020-09-09 11:00:00, False), (The description, 4, 2020-09-10 09:00:00, False)"
+    SQL_QUERY = 'INSERT INTO `modem_events` (`description`, `priority`, `created_at`, `maintenance`) VALUES ("The description", 4, "2020-09-09 11:00:00", False), ("The description", 4, "2020-09-10 09:00:00", False)'
     cursor_mock = MagicMock()
     CONNECTION_MOCK.cursor.return_value = cursor_mock
     connect_mock.return_value = CONNECTION_MOCK
@@ -161,7 +161,7 @@ class TestModemReporter(unittest.TestCase):
       ['Time Not Established', 'Error (4)', 'The description'],
       ['Time Not Established', 'Error (4)', 'The description']
     ]
-    SQL_QUERY = "INSERT INTO `modem_events` (`description`, `priority`, `created_at`, `maintenance`) VALUES (The description, 4, 2020-09-15 13:05:00, False), (The description, 4, 2020-09-15 13:05:00, False), (The description, 4, 2020-09-15 13:05:00, False)"
+    SQL_QUERY = 'INSERT INTO `modem_events` (`description`, `priority`, `created_at`, `maintenance`) VALUES ("The description", 4, "2020-09-15 13:05:00", False), ("The description", 4, "2020-09-15 13:05:00", False), ("The description", 4, "2020-09-15 13:05:00", False)'
     cursor_mock = MagicMock()
     CONNECTION_MOCK.cursor.return_value = cursor_mock
     connect_mock.return_value = CONNECTION_MOCK
@@ -182,7 +182,7 @@ class TestModemReporter(unittest.TestCase):
       ['Wed Sep 09 11:00:00 2020', 'Error (4)', 'The description'],
       ['Thu Sep 10 09:00:00 2020', 'Error (4)', 'The description']
     ]
-    SQL_QUERY = "INSERT INTO `modem_events` (`description`, `priority`, `created_at`, `maintenance`) VALUES (The description, 4, 2020-09-09 11:00:00, False), (The description, 4, 2020-09-09 11:00:00, False), (The description, 4, 2020-09-10 09:00:00, False)"
+    SQL_QUERY = 'INSERT INTO `modem_events` (`description`, `priority`, `created_at`, `maintenance`) VALUES ("The description", 4, "2020-09-09 11:00:00", False), ("The description", 4, "2020-09-09 11:00:00", False), ("The description", 4, "2020-09-10 09:00:00", False)'
     cursor_mock = MagicMock()
     CONNECTION_MOCK.cursor.return_value = cursor_mock
     connect_mock.return_value = CONNECTION_MOCK
@@ -197,13 +197,13 @@ class TestModemReporter(unittest.TestCase):
     CONNECTION_MOCK.close.assert_called_once()
 
   @patch('mysql.connector.connect')
-  def test_report_events_when_an_later_event_has_no_time_established(self, connect_mock):
+  def test_report_events_when_a_later_event_has_no_time_established(self, connect_mock):
     EVENTS = [
       ['Wed Sep 09 11:00:00 2020', 'Error (4)', 'The description'],
       ['Thu Sep 10 09:00:00 2020', 'Error (4)', 'The description'],
       ['Time Not Established', 'Error (4)', 'The description']
     ]
-    SQL_QUERY = "INSERT INTO `modem_events` (`description`, `priority`, `created_at`, `maintenance`) VALUES (The description, 4, 2020-09-09 11:00:00, False), (The description, 4, 2020-09-10 09:00:00, False), (The description, 4, 2020-09-10 09:00:00, False)"
+    SQL_QUERY = 'INSERT INTO `modem_events` (`description`, `priority`, `created_at`, `maintenance`) VALUES ("The description", 4, "2020-09-09 11:00:00", False), ("The description", 4, "2020-09-10 09:00:00", False), ("The description", 4, "2020-09-10 09:00:00", False)'
     cursor_mock = MagicMock()
     CONNECTION_MOCK.cursor.return_value = cursor_mock
     connect_mock.return_value = CONNECTION_MOCK


### PR DESCRIPTION
## What
There was a SQL error occurring during the reporting of modem events:
```
 ERROR: Unexpected error: <class 'mysql.connector.errors.ProgrammingError'>
Traceback (most recent call last):
  File "/home/pi/Code/internet-status-reporter/src/DatabaseInteractor.py", line 67, in execute_sql_with_commit
    cursor.execute(sql)
  File "/home/pi/.local/lib/python3.7/site-packages/mysql/connector/cursor.py", line 551, in execute
    self._handle_result(self._connection.cmd_query(stmt))
  File "/home/pi/.local/lib/python3.7/site-packages/mysql/connector/connection.py", line 490, in cmd_query
    result = self._handle_result(self._send_cmd(ServerCmd.QUERY, query))
  File "/home/pi/.local/lib/python3.7/site-packages/mysql/connector/connection.py", line 395, in _handle_result
    raise errors.get_exception(packet)
mysql.connector.errors.ProgrammingError: 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'Timing Synchronization failure - Failed to acquire FEC ..., 3, 2020-10-12 23:36:' at line 1
```
which wasn't able to be deduced until the recent addition of more logging, which showed the SQL that was actually attempted to be run. This PR _should_ solve this issue.

## Changes
- Updated
  - `value_string` so the `description` and `created_at` values in the SQL string are properly surrounded in quotations
  -  tests related to the change