### PR TITLE
Toggle ModemReporter

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,6 +7,7 @@ LATENCY_ADDRESSES = ""
 LATENCY_RUNS = 10
 LOG_FILE = "log.txt"
 MAILTO = "receiver@gmail.com"
+MODEM_REPORTING = 0
 MODEM_ADDRESS = "http://192.168.100.1"
 MODEM_PASSWORD = "admin"
 MODEM_USERNAME = "admin"

--- a/.env.test
+++ b/.env.test
@@ -6,6 +6,7 @@ HOST_ADDRESSES = ""
 LATENCY_ADDRESSES = ""
 LATENCY_RUNS = 10
 MAILTO = "receiver@gmail.com"
+MODEM_REPORTING = 1
 MODEM_ADDRESS = "http://0.0.0.0"
 MODEM_PASSWORD = "password"
 MODEM_USERNAME = "username"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,27 +10,29 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: "3.6"
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
+        with:
+          version: 1.1.15
 
       - name: Run setup
         run: |
           poetry install
           cp .env.sample .env
-          
+
       - name: Generate coverage
         run: |
           chmod +x $GITHUB_WORKSPACE/scripts/generate_coverage.sh
           sh $GITHUB_WORKSPACE/scripts/generate_coverage.sh
-      
+
       - name: Upload coverage
         uses: codacy/codacy-coverage-reporter-action@master
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: $GITHUB_WORKSPACE/coverage.xml
-     
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,27 +7,46 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ "ubuntu-latest" ]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10" ]
 
+    runs-on: ${{ matrix.os }}
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.6"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
           version: 1.1.15
+          virtualenvs-create: true
+          virtualenvs-in-project: true
 
-      - name: Run setup
-        run: |
-          poetry install
-          cp .env.sample .env
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v3
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root
+
+      - name: Create .env
+        run: cp .env.sample .env
 
       - name: Run tests
         run: |
+          source .venv/bin/activate
           chmod +x $GITHUB_WORKSPACE/scripts/run_tests.sh
           sh $GITHUB_WORKSPACE/scripts/run_tests.sh
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches: [ main ]
   push:
     branches: [ main ]
 
@@ -12,21 +11,23 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: "3.6"
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
+        with:
+          version: 1.1.15
 
       - name: Run setup
         run: |
           poetry install
           cp .env.sample .env
-          
+
       - name: Run tests
         run: |
           chmod +x $GITHUB_WORKSPACE/scripts/run_tests.sh
           sh $GITHUB_WORKSPACE/scripts/run_tests.sh
-     
+

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -9,8 +9,8 @@ PYTHON_MET=false
 PIP_MET=false
 POETRY_MET=false
 
-PIP3_REGEX='^pip.+(python\ 3.[6-9].+)$'
-PYTHON3_6_REGEX='^Python\ 3\.[6-9].+$'
+PIP3_REGEX='^pip.+(python\ 3\.([6-9]|1[0-9]).+)$'
+PYTHON3_6_REGEX='^Python\ 3\.([6-9]|1[0-9]).+$'
 PYTHON_VERSION="$( python --version )"
 PYTHON3_VERSION="$( python3 --version )"
 
@@ -61,8 +61,7 @@ if [ "$POETRY_MET" != "true" ]; then
 		echo "Poetry is not installed!"
 		echo "Installing poetry..."
 
-		$("curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -")
-		exec bash
+		$("curl -sSL https://install.python-poetry.org | python3 - --version 1.1.15")
 		POETRY_MET=true
 	fi
 fi

--- a/src/ModemReporter.py
+++ b/src/ModemReporter.py
@@ -14,6 +14,7 @@ class ModemReporter(DatabaseInteractor):
       'home': MODEM_ADDRESS,
       'logout': MODEM_ADDRESS + '/logout.asp'
     }
+    self.enabled = bool(int(getenv('MODEM_REPORTING')))
 
   def __setup_browser(self):
     from mechanicalsoup import StatefulBrowser
@@ -22,9 +23,10 @@ class ModemReporter(DatabaseInteractor):
     self.browser.set_verbose(2)
 
   def run(self):
-    self.login()
-    self.report_events(self.scrape_events())
-    self.logout()
+    if self.enabled:
+        self.login()
+        self.report_events(self.scrape_events())
+        self.logout()
 
   def filter_event_logs(self, event_logs):
     last_event = self.get_last_logged_event()

--- a/src/tests/ModemReporter_test.py
+++ b/src/tests/ModemReporter_test.py
@@ -221,13 +221,27 @@ class TestModemReporter(unittest.TestCase):
   @patch.object(ModemReporter, 'logout')
   @patch.object(ModemReporter, 'report_events')
   @patch.object(ModemReporter, 'scrape_events')
-  def test_run(self, login_mock, logout_mock, report_events_mock, scrape_events_mock):
+  def test_run_when_enabled(self, login_mock, logout_mock, report_events_mock, scrape_events_mock):
+    self.modemReporter.enabled = True
     self.modemReporter.run()
 
     login_mock.assert_called_once()
     scrape_events_mock.assert_called_once()
     report_events_mock.assert_called_once()
     logout_mock.assert_called_once()
+
+  @patch.object(ModemReporter, 'login')
+  @patch.object(ModemReporter, 'logout')
+  @patch.object(ModemReporter, 'report_events')
+  @patch.object(ModemReporter, 'scrape_events')
+  def test_run_when_not_enabled(self, login_mock, logout_mock, report_events_mock, scrape_events_mock):
+    self.modemReporter.enabled = False
+    self.modemReporter.run()
+
+    login_mock.assert_not_called()
+    scrape_events_mock.assert_not_called()
+    report_events_mock.assert_not_called()
+    logout_mock.assert_not_called()
 
   def test_scrape_events(self):
     from bs4 import BeautifulSoup


### PR DESCRIPTION
## What
In the new age of fiber, sometimes there is no modem to get logs from. This adds the ability to turn on and off the running of the `ModemReporter` with the `MODEM_REPORTING` env var, now found in `.env.sample`. If the `MODEM_REPORTING` variable isn't found, the `ModemReporter` will default to _not running_.

## Changes
  - Updated
    - `ModemReporter` to be enabled/disabled based on the `MODEM_REPORTING` env var
    - `workflows` 
      - to fix an issue where the actions would fail from an error
      - and update the `main` workflow to have more extensible testing strategies, for longer backwards compatibility